### PR TITLE
add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go:
+ - 1.4.1
+ - 1.5.3
+ - tip
+
+install:
+ - go get github.com/tools/godep
+
+script:
+ - make test


### PR DESCRIPTION
Fixes #16.

I could not fully test it, since the package structure on my forked repository is different. But I think we can make adjustments also after merging if necessary. The owners still need to create an account with Travis CI (login with Github), sync repositories and flip the switch on this repository to enable Travis builds.
