### PR TITLE
workaround for go-yaml behavior

### DIFF
--- a/mml/mml.go
+++ b/mml/mml.go
@@ -23,7 +23,7 @@ type auxMML struct {
 }
 
 type auxLayer struct {
-	Datasource map[string]interface{}
+	Datasource map[string]interface{} `yaml:"Datasource"`
 	Geometry   string
 	ID         string
 	Name       string
@@ -133,7 +133,7 @@ func Parse(r io.Reader) (*MML, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = yaml.Unmarshal(input, &aux)
+	err = yaml.Unmarshal([]byte(input), &aux)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Unfortunately, there is an annoying "feature" in go-yaml that ignores uppercase keys. See https://github.com/go-yaml/yaml/issues/148 for details. So we have to work around this by replacing the uppercase `Datasource` key by a lower case version.

Please merge before #23. Maybe I will need to resolve merge conflicts on #23 afterwards.
