### PR TITLE
use CDATA for datasource parameters when generating Mapnik XML

### DIFF
--- a/builder/mapnik/elements.go
+++ b/builder/mapnik/elements.go
@@ -16,7 +16,7 @@ type XMLMap struct {
 
 type Parameter struct {
 	Name  string `xml:"name,attr"`
-	Value string `xml:",chardata"`
+	Value string `xml:",cdata"`
 }
 
 type FontSet struct {


### PR DESCRIPTION
Available in Go 1.6 only.
If CDATA is not used the content is XML encoded, which can lead to problems especially with the SQL queries. With CDATA the content stays untouched.
