### PR TITLE
correct Mapnik ShieldSymbolizer dx/dy mapping

### DIFF
--- a/builder/mapnik/elements.go
+++ b/builder/mapnik/elements.go
@@ -169,8 +169,8 @@ type ShieldSymbolizer struct {
 	AvoidEdges       *string  `xml:"avoid-edges,attr"`
 	CharacterSpacing *string  `xml:"character-spacing,attr"`
 	Clip             *string  `xml:"clip,attr"`
-	Dx               *string  `xml:"dx,attr"`
-	Dy               *string  `xml:"dy,attr"`
+	Dx               *string  `xml:"shield-dx,attr"`
+	Dy               *string  `xml:"shield-dy,attr"`
 	FaceName         *string  `xml:"face-name,attr"`
 	File             *string  `xml:"file,attr"`
 	Fill             *string  `xml:"fill,attr"`
@@ -185,8 +185,8 @@ type ShieldSymbolizer struct {
 	Placement        *string  `xml:"placement,attr"`
 	Size             *string  `xml:"size,attr"`
 	Spacing          *string  `xml:"spacing,attr"`
-	TextDx           *string  `xml:"text-dx,attr"`
-	TextDy           *string  `xml:"text-dy,attr"`
+	TextDx           *string  `xml:"dx,attr"`
+	TextDy           *string  `xml:"dy,attr"`
 	TextOpacity      *string  `xml:"text-opacity,attr"`
 	TextTransform    *string  `xml:"text-transform,attr"`
 	WrapBefore       *string  `xml:"wrap-before,attr"`


### PR DESCRIPTION
There is a bug in the ShieldSymbolizer dx/dy mapping. The shield dx/dy should be mapped to `shield-dx/dy` and the text dx/dy should be mapped to `dx/dy`. See https://github.com/mapnik/mapnik/wiki/TextSymbolizer for details.
