### PR TITLE
add coveralls test coverage measurement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: go
 go:
- - 1.4.1
  - 1.5.3
  - tip
+
+before_install:
+ - go get github.com/axw/gocov/gocov
+ - go get github.com/go-playground/overalls
+ - go get github.com/mattn/goveralls
+ - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 
 install:
  - go get github.com/tools/godep
 
 script:
- - make test
+ - make test-coverage
+ - $HOME/gopath/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,6 @@ test:
 test-full:
 	$(GO) test -i $(FULL_TEST_PACKAGES)
 	export PATH=$(shell pwd):$$PATH; $(GO) test -parallel 4 $(FULL_TEST_PACKAGES)
+
+test-coverage:
+	$(if $(shell go version |grep 'go1.5'), GO15VENDOREXPERIMENT=1,) $(GOPATH)/bin/overalls -project=github.com/omniscale/magnacarto -debug -covermode=count -ignore=.git,Godeps,vendor,app,docs,render,regression


### PR DESCRIPTION
You might want to consider adding coveralls test coverage measurement as incentive to write more tests. Still needs to be enabled from within coveralls.io and a repo token in travis-ci might be needed. See https://github.com/mattn/goveralls and https://coveralls.zendesk.com/hc/en-us/articles/201342809-Go for more information.
